### PR TITLE
readme, architecture and name change

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# LicenseSentinel
+# LicenseHierarchy
 
 A toolchain for building and analyzing the dependency tree of a Python project from its requirements. Includes software license analysis (scancode), license compatibility verification.
 
@@ -16,50 +16,36 @@ A toolchain for building and analyzing the dependency tree of a Python project f
 
 ### Python Dependencies
 
-Install the project dependencies:
+The projects' dependencies are reported in `src/requirements-dev.txt`; these will be downloaded automatically during the installation process
 
+To install, head to the **[Release Tab](https://github.com/License-Compliance-Group/LicenseSentinel/releases)** and follow the steps reported in the release you wish for.
+
+Alteratively, you may download the latest version released on PyPi with the following command:  
 ```bash
-pip install -r src/requirements-dev.txt
+python -m pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple license-hierarchy
 ```
-
-### External Tool: ScanCode Toolkit
-
-> ⚠️ **Important:** This project depends on **[ScanCode Toolkit](https://github.com/nexB/scancode-toolkit)** for source code license detection.
-
-Install ScanCode separately:
-
-```bash
-pip install scancode-toolkit
-```
-
-Or download the pre-built binary from the [official releases](https://github.com/nexB/scancode-toolkit/releases) (⚠️ reccomaned).
 
 ## Usage
 
-### For Users
-
-If installed from PyPI:
+Once installed, you can run LicenseHierarchy by typing the following command:
 
 ```bash
-licensesentinel
-```
+license-hierarchy
+```  
 
-### For Developers
+To use the tool, provide the path of the `requirements.txt` file containing the dependencies of your project in the text box.  
+Select the license under which your project will be released, and wait for the dependencies specified in `requirements.txt` in the venv.
 
-Run the TUI in development mode from the `src/` directory:
-
-```bash
-textual run --dev licensesentinel.py
-```
 
 ## Project Structure
 
 ```
-src/
-├── entities/        # Domain layer: models & abstract interfaces
-├── analyzer/        # Business logic layer
-├── infrastructure/  # I/O layer: HTTP, filesystem, processes
-└── interface/       # UI layer: GUI & controller
+src/license_sentinel
+├── entities/           # Domain layer: models & abstract interfaces
+├── analyzer/           # Business logic layer
+├── infrastructure/     # I/O layer: HTTP, filesystem, processes
+├── interface/          # UI layer: GUI & controller
+└── licensesentinel.py  # Entrypoint
 ```
 
 ## License

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ The projects' dependencies are reported in `src/requirements-dev.txt`; these wil
 
 To install, head to the **[Release Tab](https://github.com/License-Compliance-Group/LicenseSentinel/releases)** and follow the steps reported in the release you wish for.
 
-Alteratively, you may download the latest version released on PyPi with the following command:  
+Alternatively, you may download the latest version released on PyPi with the following command:  
 ```bash
 python -m pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple license-hierarchy
 ```

--- a/doc/ARCHITECTURE.md
+++ b/doc/ARCHITECTURE.md
@@ -1,4 +1,4 @@
-# LicenseSentinel - Documentazione Architettura
+# LicenseHierarchy - Documentazione Architettura
 
 Toolchain per la costruzione e analisi dell'albero delle dipendenze di un progetto python a partire dai suoi requirements. Include l'analisi delle licenze software, la verifica della compatibilità tra licenze e l'ispezione automatica del codice sorgente. Quest'ultima consiste nel verificare che la licenza su PyPI corrisponda a quella del repository originale
 
@@ -10,12 +10,12 @@ rich
 pipdeptree
 scancode-toolkit (se non funziona provate il bianrio)
 ```
-per runnare il programma, momentaneamente
+gli import relativi funzionano solo quando viene eseguito come modulo, per runnarlo senza installarlo tramite il wheel fate
 
 ```
-textual run --dev temp.py
+python -m license_sentinel.licensesentinel
 ```
-dalla cartella LicenseChecker/src (src è la root)
+Non mi ricordo mai se sta cosa dovete farla dalla root oppure da src, vedete voi
 
 ## Architettura a Strati (Onion Architecture)
 
@@ -54,7 +54,7 @@ Tale architettura segue quindi le seguenti regole di dipendenza
 ## Struttura di packages e moduli
 
 ```
-src/
+src/license_sentinel
 ├── entities/                           # Strato 1: Dominio e Astrazioni
 │   ├── pypi_metadata.py                # Contenitore metadati PyPI
 │   ├── scan_engine.py                  # Interfaccia per scanner di licenze
@@ -78,12 +78,13 @@ src/
 │   ├── connectivity.py                 # Gestisce I/O (download, cache)
 │   └── logger_formatter.py             # Configurazione logging
 │
-└── interface/                           # Strato 4: Interfaccia Utente
-    ├── gui.py                           # Interfaccia grafica (Textual)
-    ├── controller.py                    # Controller principale UI
-    ├── ui_state.py                      # Gestione stato UI
-    └── style.css                        # Stili UI
-
+├── interface/                          # Strato 4: Interfaccia Utente
+│   ├── gui.py                          # Interfaccia grafica (Textual)
+│   ├── controller.py                   # Controller principale UI
+│   ├── ui_state.py                     # Gestione stato UI
+│   └── style.css                       # Stili UI
+│
+└────── licensesentinel.py              # Entrypoint
 ```
 
 ## Flusso di Esecuzione Principale
@@ -151,7 +152,6 @@ START
       - Report grafico
 ```
 
-### "LA COSA STRANA" DEI METODI ASTRATTI E' DEPENDENCY INEJCTION - LA UI USA UNA SPECIE DI MACCHINA A STATI (TRAMITE SWITCH/MATCH) PER DISTINGUERE LE VARIE SCHERMATE ADFESSO INIZIA CHAGPT POI AGGIUSTO.
 
 ## Descrizione Dettagliata dei Moduli. 
 ### 4️⃣ ENTITIES (Strato di Dominio)
@@ -627,10 +627,10 @@ scancode-toolkit        # Scansione licenze (opzionale, WIP)
 
 ### Requisiti di Sistema
 
-- Python 3.8+
-- pip
+- Python 3.10+
 - git (per download repository)
 - virtualenv (generalmente bundled con Python)
+- pip (generalmente bundled con Python)
 
 ---
 
@@ -707,18 +707,16 @@ for meta in metadata:
 - [x] Matrice compatibilità licenze
 - [x] GUI Textual (struttura base)
 - [x] Normalizzazione nomi licenze
+- [x] Parsing completo output ScanCode
+- [x] Completamento UI
+
 
 ### 🔄 Work in Progress
 
-- [ ] Parsing completo output ScanCode
-- [ ] Classe `ScanCodeResult` (attualmente stub)
 - [ ] Report esportabili (CSV, PDF)
-- [ ] Completamento UI
 
-### ⚠️ Note Importanti
+### ⚠️ Nota Importante
 
-- `ScanCodeResult` e classi correlate non sono ancora implementate
-- Alcuni widget UI sono placeholder
 - La matrice di compatibilità potrebbe essere offline o richiedere download
 
 ---

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,8 +3,8 @@ requires = ["setuptools>=61.0", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
-name = "license-sentinel"
-version = "1.0"
+name = "license-hierarchy"
+version = "1.0.1"
 description = "A tool for analyzing Python project dependencies and verifying license compatibility"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -36,7 +36,7 @@ dev = [
 ]
 
 [project.scripts]
-license-sentinel = "license_sentinel.licensesentinel:main"
+license-hierarchy = "license_sentinel.licensesentinel:main"
 
 [project.urls]
 Homepage = "https://github.com/License-Compliance-Group/LicenseSentinel"


### PR DESCRIPTION
on pypi there seems to be a license-sentinel already published, so i had to change the name to license-hierarchy to publsh.  
BUT THEN I forgot to change the entry script so it was still license-sentinel, as such I had to push a new release under version 1.0.1  

changes to toml reflect this